### PR TITLE
Add support for layer-wise lt-sft

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -1,3 +1,8 @@
-python train.py --checkpoint Helsinki-NLP/opus-mt-es-fi \
-   --out_model_name es_fi_quz --extra_data_codes quy quz --epochs 20 \
-   --push_to_hub --lt-sft --K 0.05
+python train.py \
+  --checkpoint Helsinki-NLP/opus-mt-es-fi \
+  --out_model_name es_fi_quz \
+  --extra_data_codes quy quz \
+  --epochs 20 \
+  --push_to_hub \
+  --encoder 0 0 0 0 0 0 \
+  --decoder 0.1 0.2 0.3 0.4 0.5 0.6


### PR DESCRIPTION
Add a new `get_mask_layerwise` which allows you to specify the percentage of parameters to fine tune in all 12 of the transformer layers (6 in the encoder and 6 in the decoder).

If you look at the new `train.sh` script, you will see how to run the code. Basically, you pass in an array with 6 values p_i \in [0, 1] where p_i represents the percentage of params in layer i of the encoder to fine-tune. Similarly, you pass in an array with 6 values q_j \in [0, 1] where q_j represents the percentage of params in layer j of the decoder to fine-tune.